### PR TITLE
Added extra relationship metadataThumbnail

### DIFF
--- a/Sources/CoreXLSX/Relationships.swift
+++ b/Sources/CoreXLSX/Relationships.swift
@@ -24,6 +24,7 @@ public struct Relationship: Codable, Equatable {
     case styles = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"
     case theme = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
     case pivotCache = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition"
+    case metdataThumbnail = "http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail"
   }
 
   public let id: String


### PR DESCRIPTION
dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "relationship", intValue: nil), _XMLKey(stringValue: "Index 3", intValue: 3), CodingKeys(stringValue: "type", intValue: nil)], debugDescription: "Cannot initialize SchemaType from invalid String value http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail", underlyingError: nil))